### PR TITLE
Update intersection observer hook usage

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -30,8 +30,7 @@ export default function AdminDashboard() {
 
   // Intersection observer for infinite scroll
   const loadMoreRef = useRef<HTMLDivElement>(null)
-  const entry = useIntersectionObserver(loadMoreRef, {})
-  const isIntersecting = entry?.isIntersecting
+  const { entry, isIntersecting } = useIntersectionObserver(loadMoreRef)
 
   useEffect(() => {
     const fetchAdminUserAndConversations = async () => {

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -3,16 +3,16 @@
 import { useEffect, useState, RefObject } from 'react'
 
 interface UseIntersectionObserverProps {
-  elementRef: RefObject<HTMLElement | null>
   threshold?: number | number[]
   root?: Element | null
   rootMargin?: string
   freezeOnceVisible?: boolean
 }
 
-export function useIntersectionObserver(loadMoreRef: RefObject<HTMLDivElement | null>, p0: {}, {
-  elementRef, threshold = 0, root = null, rootMargin = '0%', freezeOnceVisible = false
-}: UseIntersectionObserverProps) {
+export function useIntersectionObserver(
+  elementRef: RefObject<HTMLElement | null>,
+  { threshold = 0, root = null, rootMargin = '0%', freezeOnceVisible = false }: UseIntersectionObserverProps = {}
+) {
   const [entry, setEntry] = useState<IntersectionObserverEntry | null>(null)
   const [isIntersecting, setIsIntersecting] = useState(false)
 


### PR DESCRIPTION
## Summary
- adjust `useIntersectionObserver` hook to take an element ref and optional options
- update admin dashboard to consume new hook API

## Testing
- `yarn lint` *(fails: many existing lint errors)*
- `yarn test` *(fails: runs Playwright tests which hang)*

------
https://chatgpt.com/codex/tasks/task_e_68600b74dc60832a9553f3ded12664a7