### PR TITLE
Use env var for Sentry DSN

### DIFF
--- a/Documentation/Technical-Reference/TECHNICAL-SETUP.md
+++ b/Documentation/Technical-Reference/TECHNICAL-SETUP.md
@@ -96,6 +96,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=CherryGifts Chat
 NEXT_PUBLIC_DEBUG_MODE=true
+# Sentry configuration
+# Use your own DSN in production. A default DSN can remain for local testing.
+NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
 ```
 
 ### Supabase Clients

--- a/app/components/SentryInitializer.tsx
+++ b/app/components/SentryInitializer.tsx
@@ -8,7 +8,7 @@ export function SentryInitializer() {
     // Always initialize Sentry in development, or if NEXT_PUBLIC_SENTRY_ENABLED is true, or in production
     if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'production' || process.env.NEXT_PUBLIC_SENTRY_ENABLED === 'true') {
       Sentry.init({
-        dsn: "https://3179da9c078565b8682aa3f466390b16@o4509331430113280.ingest.de.sentry.io/4509474585116752",
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
         debug: true, // Always enable debug mode in development, can be conditional for production
         tracesSampleRate: 1.0, // Capture 100% of transactions for performance monitoring
         // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled


### PR DESCRIPTION
## Summary
- reference env var `NEXT_PUBLIC_SENTRY_DSN` in `SentryInitializer`
- document Sentry DSN variable for local testing

## Testing
- `yarn lint` *(fails: many lint errors)*
- `yarn test` *(runs Playwright; serves HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_686030de65ac832a98988d63687acdb7